### PR TITLE
docs: add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing Guidelines
+
+## Making a pull request
+
+Please keep the following points in mind while making a pull request:
+
+- For Vala source, follow the [elementary code style](https://docs.elementary.io/develop/writing-apps/code-style). Running [vala-lint](https://github.com/vala-lang/vala-lint) will help you there.
+- Keep the pull requests small. For large features, try to break the changes into multiple modular pull requests.
+- Add or modify unit tests wherever applicable. These reside in the `tests` directory.


### PR DESCRIPTION
Added a basic CONTRIBUTING.md as per the points discussed.

I'm also considering creating a CODE_OF_CONDUCT.md and linking to it from this file. The contents could be taken from https://www.contributor-covenant.org/.